### PR TITLE
Fix unused icon import

### DIFF
--- a/src/components/ServicePage.tsx
+++ b/src/components/ServicePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import Button from './Button';
 import FadeInSection from './FadeInSection';
 


### PR DESCRIPTION
## Summary
- remove unused runtime icon import in `ServicePage`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6843807a6a10832598672d85f256e586